### PR TITLE
Search query must query also the upn as mail could be null or different

### DIFF
--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -135,7 +135,7 @@ export default class SPPeopleSearchService {
 
       // Check if users need to be searched in a specific Microsoft 365 Group, Security Group (incl. nested groups) or Distribution List
       else if (groupId && typeof (groupId) === 'string') {
-        const graphUserRequestUrl = `/groups/${groupId}/transitiveMembers?$count=true&$search="displayName:${query}" OR "mail:${query}"`;
+        const graphUserRequestUrl = `/groups/${groupId}/transitiveMembers?$count=true&$search="userPrincipalName:${query}" OR "displayName:${query}" OR "mail:${query}" `;
         const graphClient = await this.context.msGraphClientFactory.getClient("3");
         const graphUserResponse = await graphClient.api(graphUserRequestUrl).header('ConsistencyLevel', 'eventual').get();
 

--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -135,7 +135,7 @@ export default class SPPeopleSearchService {
 
       // Check if users need to be searched in a specific Microsoft 365 Group, Security Group (incl. nested groups) or Distribution List
       else if (groupId && typeof (groupId) === 'string') {
-        const graphUserRequestUrl = `/groups/${groupId}/transitiveMembers?$count=true&$search="userPrincipalName:${query}" OR "displayName:${query}" OR "mail:${query}" `;
+        const graphUserRequestUrl = `/groups/${groupId}/transitiveMembers?$count=true&$search="userPrincipalName:${query}" OR "displayName:${query}" OR "mail:${query}"`;
         const graphClient = await this.context.msGraphClientFactory.getClient("3");
         const graphUserResponse = await graphClient.api(graphUserRequestUrl).header('ConsistencyLevel', 'eventual').get();
 


### PR DESCRIPTION
PeopleSearch service should also find people by userPrincipalName when group transitive membership check is used. If the user does not have an email or the email is different from userPrincipalName currently it is not returned. 

| Q               | A
| --------------- | ---
| Bug fix?        | [ X ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

This PR adds the userPrincipalName filter to the query. 